### PR TITLE
Funding acknowledgement; missing licence

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,11 @@
+# CN1
+(Description should go here. Dependencies, how to compile, install, ... )
+
+## Licence
+(Link to licence file to be added here.)
+
+## Funding Acknowledgement
+
+The research leading to these results has received funding from the European
+Union's Seventh Framework Programme (FP7/2007-2013) under grant agreement No.289016
+([Cloud4all](http://www.cloud4all.info/)).


### PR DESCRIPTION
Hi,

Is this repo still relevant? If yes, what is it for? 

I'm adding the standard funding acknowledgement, which needs to be added in any case (i.e. in any public code repositories of Cloud4all). 

Please also add a licence file (BSD 3-Clause license, MIT License or Apache License 2.0, unless you have a good reason to use something more restrictive such as LGPL).
